### PR TITLE
Backport upstream fix: fixed typo in register mod

### DIFF
--- a/VL53L0X.cpp
+++ b/VL53L0X.cpp
@@ -843,7 +843,7 @@ bool VL53L0X::getSPADInfo(uint8_t* count, bool* typeIsAperture) {
 
 	this->writeRegister(0x81, 0x00);
 	this->writeRegister(0xFF, 0x06);
-	this->writeRegister(0x83, this->readRegister(0x83 & ~0x04));
+	this->writeRegister(0x83, this->readRegister(0x83) & ~0x04);
 	this->writeRegister(0xFF, 0x01);
 	this->writeRegister(0x00, 0x01);
 


### PR DESCRIPTION
I applied a fix in the upstream library from Pololu:

https://github.com/pololu/vl53l0x-arduino/pull/7

Anyway, thanks for this nice port to Linux.

Out of curiosity, I have some questions about your work:
1. Why do you precise `this->` with every method and argument of the class? It is a lot more verbose. But do you find it clearer?
2. Why do try to force the use of GCC 6 in the CMake file? Note that if GCC 6 is not found, it defaults to an older version installed that obviously does not support C++11 by default so we have to add the `--std=c++11` flag.
3. Why do you provide amd64 binaries (add a lot of noise in the repo/CMake...) for a package that is supposed to be run on an Odroid or Raspberry Pi, both ARM processors?

:+1: for the clear documentation in the README.